### PR TITLE
Change `document_type` hardcodes to "public"

### DIFF
--- a/docassemble/AppearanceEfile/data/questions/appearance.yml
+++ b/docassemble/AppearanceEfile/data/questions/appearance.yml
@@ -1687,7 +1687,7 @@ review:
         - IL_fee_waiver_supplement.document_type
         - IL_fee_waiver_order.document_type
     button: |
-      % if illinois_appearance_attachment.document_type in ['5766', '141579', '133166', '273947']:
+      % if illinois_appearance_attachment.document_type in ['5766', '141579', '133166', '273947', '302243']:
       The judge **did not order the case to be sealed**.
       % else:
       The judge **did order the case to be sealed**.

--- a/docassemble/AppearanceEfile/data/questions/appearance.yml
+++ b/docassemble/AppearanceEfile/data/questions/appearance.yml
@@ -1687,7 +1687,7 @@ review:
         - IL_fee_waiver_supplement.document_type
         - IL_fee_waiver_order.document_type
     button: |
-      % if illinois_appearance_attachment.document_type == '5766' or illinois_appearance_attachment.document_type == '141579' or illinois_appearance_attachment.document_type == '133166':
+      % if illinois_appearance_attachment.document_type in ['5766', '141579', '133166', '273947']:
       The judge **did not order the case to be sealed**.
       % else:
       The judge **did order the case to be sealed**.

--- a/docassemble/AppearanceEfile/data/questions/efile_ports.yml
+++ b/docassemble/AppearanceEfile/data/questions/efile_ports.yml
@@ -127,8 +127,20 @@ code: |
     filter_list = []
   illinois_appearance_bundle.optional_services_defaults = default_list
   illinois_appearance_bundle.optional_services_filters = filter_list
-  illinois_appearance_bundle.document_type_filters = ['public']
-  illinois_appearance_bundle.document_type_default = "273947"
+  illinois_appearance_bundle.document_type_filters = public_document_type_filter(court_id)
+  illinois_appearance_bundle.document_type_default = public_document_type(court_id)
+---
+code: |
+  def public_document_type(active_court_id):
+    # Always use None for the default: more resilient
+    return None
+---
+code: |
+  def public_document_type_filter(active_court_id):
+    if active_court_id in ['kankakee', 'KankakeeCR', 'KankakeeCV', 'KankakeeTR', 'KankakeeFAM']:
+      return ["public"]
+    else:
+      return ["non-confidential"]
 ---
 code: |
   if illinois_appearance_bundle.optional_services[i].code in ["124679", "20774", "20773", "257784"]:
@@ -181,35 +193,35 @@ if: illinois_jury_demand_bundle.enabled
 code: |
   illinois_jury_demand_bundle.optional_services_defaults = []
   illinois_jury_demand_bundle.optional_services_filters = []
-  illinois_jury_demand_bundle.document_type_filters = ['public']
-  illinois_jury_demand_bundle.document_type_default = "273947"
+  illinois_jury_demand_bundle.document_type_filters = public_document_type_filter(court_id)
+  illinois_jury_demand_bundle.document_type_default = public_document_type(court_id)
 ---
 code: |
   illinois_appearance_attachment.filing_component_default = '332'
   illinois_appearance_attachment.filing_component_filters = ['Lead Document']
   illinois_appearance_attachment.document_description = 'Appearance'
-  illinois_appearance_attachment.document_type_default = "273947"
-  illinois_appearance_attachment.document_type_filters = ['public']
+  illinois_appearance_attachment.document_type_default = public_document_type(court_id)
+  illinois_appearance_attachment.document_type_filters = public_document_type_filter(court_id)
   illinois_appearance_additional.filing_component_default = '331'
   illinois_appearance_additional.filing_component_filters = ['Attachment']
   illinois_appearance_additional.document_description = 'Appearance Additional Proof of Delivery'
-  illinois_appearance_additional.document_type_default = "273947"
-  illinois_appearance_additional.document_type_filters = ['public']
+  illinois_appearance_additional.document_type_default = public_document_type(court_id)
+  illinois_appearance_additional.document_type_filters = public_document_type_filter(court_id)
   illinois_appearance_additional_2.filing_component_default = '331'
   illinois_appearance_additional_2.filing_component_filters = ['Attachment']
-  illinois_appearance_additional_2.document_type_default = "273947"
-  illinois_appearance_additional_2.document_type_filters = ['public']
+  illinois_appearance_additional_2.document_type_default = public_document_type(court_id)
+  illinois_appearance_additional_2.document_type_filters = public_document_type_filter(court_id)
   illinois_appearance_additional_2.document_description = 'Appearance Additional Proof of Delivery'
   illinois_appearance_additional_3.filing_component_default = '331'
   illinois_appearance_additional_3.filing_component_filters = ['Attachment']
   illinois_appearance_additional_3.document_description = 'Appearance Additional Proof of Delivery'
-  illinois_appearance_additional_3.document_type_default = "273947"
-  illinois_appearance_additional_3.document_type_filters = ['public']
+  illinois_appearance_additional_3.document_type_default = public_document_type(court_id)
+  illinois_appearance_additional_3.document_type_filters = public_document_type_filter(court_id)
   illinois_appearance_additional_blank.filing_component_default = '331'
   illinois_appearance_additional_blank.filing_component_filters = ['Attachment']
   illinois_appearance_additional_blank.document_description = 'Appearance Additional Proof of Delivery'
-  illinois_appearance_additional_blank.document_type_default = "273947"
-  illinois_appearance_additional_blank.document_type_filters = ['public']
+  illinois_appearance_additional_blank.document_type_default = public_document_type(court_id)
+  illinois_appearance_additional_blank.document_type_filters = public_document_type_filter(court_id)
 ---
 ############# Overide some wording #########
 generic object: DAObject
@@ -249,7 +261,7 @@ fields:
     input type: radio
     code: |
       list(reversed(yes_no_confidential(x.filtered_document_type_options)))
-    default: ${ matching_tuple_option('public', x.filtered_document_type_options) }
+    default: ${ matching_tuple_option('non-confidential', x.filtered_document_type_options) }
 ---
 need:
   - ready_to_efile
@@ -333,9 +345,9 @@ code: |
   def yes_no_confidential(opts):
     new_opts = []
     for opt in opts:
-      if opt[0] in ['5766', '141579', '133166', '273947'] or opt[1].lower() == 'non-confidential' or opt[1].lower() == 'public': # public / non-confidential
+      if opt[0] in ['5766', '141579', '133166', '273947', '302243'] or opt[1].lower() in ['non-confidential', 'public']: # public / non-confidential
         new_opts.append([opt[0], "No"])
-      elif opt[0] == "5767" or opt[0] == "273946" or opt[1].lower() == 'confidential' or opt[1].lower() == 'non-public': # confidential / non-public
+      elif opt[0] in ["5767", "273946", "302242"] or opt[1].lower() in ['confidential', 'non-public']: # confidential / non-public
         new_opts.append([opt[0], "Yes"])
       else:
         new_opts.append([opt[0], f"Something else ({opt[1]})"])

--- a/docassemble/AppearanceEfile/data/questions/efile_ports.yml
+++ b/docassemble/AppearanceEfile/data/questions/efile_ports.yml
@@ -127,8 +127,8 @@ code: |
     filter_list = []
   illinois_appearance_bundle.optional_services_defaults = default_list
   illinois_appearance_bundle.optional_services_filters = filter_list
-  illinois_appearance_bundle.document_type_filters = ['non-confidential']
-  illinois_appearance_bundle.document_type_default = "5766"
+  illinois_appearance_bundle.document_type_filters = ['public']
+  illinois_appearance_bundle.document_type_default = "273947"
 ---
 code: |
   if illinois_appearance_bundle.optional_services[i].code in ["124679", "20774", "20773", "257784"]:
@@ -181,35 +181,35 @@ if: illinois_jury_demand_bundle.enabled
 code: |
   illinois_jury_demand_bundle.optional_services_defaults = []
   illinois_jury_demand_bundle.optional_services_filters = []
-  illinois_jury_demand_bundle.document_type_filters = ['non-confidential']
-  illinois_jury_demand_bundle.document_type_default = "5766"
+  illinois_jury_demand_bundle.document_type_filters = ['public']
+  illinois_jury_demand_bundle.document_type_default = "273947"
 ---
 code: |
   illinois_appearance_attachment.filing_component_default = '332'
   illinois_appearance_attachment.filing_component_filters = ['Lead Document']
   illinois_appearance_attachment.document_description = 'Appearance'
-  illinois_appearance_attachment.document_type_default = '5766' # non-confidential
-  illinois_appearance_attachment.document_type_filters = ['non-confidential']
+  illinois_appearance_attachment.document_type_default = "273947"
+  illinois_appearance_attachment.document_type_filters = ['public']
   illinois_appearance_additional.filing_component_default = '331'
   illinois_appearance_additional.filing_component_filters = ['Attachment']
   illinois_appearance_additional.document_description = 'Appearance Additional Proof of Delivery'
-  illinois_appearance_additional.document_type_default = '5766' # non-confidential
-  illinois_appearance_additional.document_type_filters = ['non-confidential']
+  illinois_appearance_additional.document_type_default = "273947"
+  illinois_appearance_additional.document_type_filters = ['public']
   illinois_appearance_additional_2.filing_component_default = '331'
   illinois_appearance_additional_2.filing_component_filters = ['Attachment']
-  illinois_appearance_additional_2.document_type_default = '5766' # non-confidential
-  illinois_appearance_additional_2.document_type_filters = ['non-confidential']
+  illinois_appearance_additional_2.document_type_default = "273947"
+  illinois_appearance_additional_2.document_type_filters = ['public']
   illinois_appearance_additional_2.document_description = 'Appearance Additional Proof of Delivery'
   illinois_appearance_additional_3.filing_component_default = '331'
   illinois_appearance_additional_3.filing_component_filters = ['Attachment']
   illinois_appearance_additional_3.document_description = 'Appearance Additional Proof of Delivery'
-  illinois_appearance_additional_3.document_type_default = '5766' # non-confidential
-  illinois_appearance_additional_3.document_type_filters = ['non-confidential']
+  illinois_appearance_additional_3.document_type_default = "273947"
+  illinois_appearance_additional_3.document_type_filters = ['public']
   illinois_appearance_additional_blank.filing_component_default = '331'
   illinois_appearance_additional_blank.filing_component_filters = ['Attachment']
   illinois_appearance_additional_blank.document_description = 'Appearance Additional Proof of Delivery'
-  illinois_appearance_additional_blank.document_type_default = '5766' # non-confidential
-  illinois_appearance_additional_blank.document_type_filters = ['non-confidential']
+  illinois_appearance_additional_blank.document_type_default = "273947"
+  illinois_appearance_additional_blank.document_type_filters = ['public']
 ---
 ############# Overide some wording #########
 generic object: DAObject
@@ -249,7 +249,7 @@ fields:
     input type: radio
     code: |
       list(reversed(yes_no_confidential(x.filtered_document_type_options)))
-    default: ${ matching_tuple_option('non-confidential', x.filtered_document_type_options) }
+    default: ${ matching_tuple_option('public', x.filtered_document_type_options) }
 ---
 need:
   - ready_to_efile
@@ -333,9 +333,9 @@ code: |
   def yes_no_confidential(opts):
     new_opts = []
     for opt in opts:
-      if opt[0] == "5766" or opt[0] == '141579' or opt[0] == '133166' or opt[1].lower() == 'non-confidential':
+      if opt[0] in ['5766', '141579', '133166', '273947'] or opt[1].lower() == 'non-confidential' or opt[1].lower() == 'public': # public / non-confidential
         new_opts.append([opt[0], "No"])
-      elif opt[0] == "5767" or opt[1].lower() == 'confidential': # confidential
+      elif opt[0] == "5767" or opt[0] == "273946" or opt[1].lower() == 'confidential' or opt[1].lower() == 'non-public': # confidential / non-public
         new_opts.append([opt[0], "Yes"])
       else:
         new_opts.append([opt[0], f"Something else ({opt[1]})"])

--- a/docassemble/AppearanceEfile/data/sources/interviews_run.feature
+++ b/docassemble/AppearanceEfile/data/sources/interviews_run.feature
@@ -155,7 +155,7 @@ Scenario: appearance.yml with e-filing, search by party name
     | users[0].email | example@example.com | |
     | user_benefits['TA'] | True | |
     | users[0].birth_year | 2000 | |
-    | x.document_type | 5766 | illinois_appearance_bundle.document_type |
+    | x.document_type | 273947 | illinois_appearance_bundle.document_type |
   And I tap the "#efile" element
   #And I tap to continue
   #Then I should see the phrase "form was submitted"

--- a/docassemble/AppearanceEfile/data/sources/interviews_run.feature
+++ b/docassemble/AppearanceEfile/data/sources/interviews_run.feature
@@ -33,11 +33,12 @@ Scenario: appearance.yml without e-filing
   Given I start the interview at "appearance.yml"
   And the maximum seconds for each Step in this Scenario is 40
   And I check all pages for accessibility issues
+  # trial_court_index 97 is Tazewell
   And I get to the question id "get-docs-screen" with this data:
     | var | value | trigger |
     | accept["I accept the terms of use."] | True | |
     | case_is_invalid_type | False | |
-    | trial_court_index | 0 | |
+    | trial_court_index | 97 | |
     | user_wants_efile | False | |
     | user_ask_role | defendant | |
     | users.target_number | 1 | |
@@ -45,7 +46,7 @@ Scenario: appearance.yml without e-filing
     | users[0].name.last | Ma | |
     | other_parties.target_number | 1 | |
     | trial_with | judge_only | |
-    | case_number | 2022AC123 | |
+    | case_number | 2022-SC-000005 | |
     | users[0].phone_number | 4094567890 | |
     | users[0].email | example@example.com | |
     | other_parties[0].person_type | ALIndividual | |
@@ -98,7 +99,7 @@ Scenario: appearance.yml attempting but failing e-filing
     | other_parties[0].name.first | Tame | |
     | other_parties[0].name.last | Impala | |
     | x.is_represented | False | other_parties[0].is_represented |
-    | case_number | 2022AC123 | |
+    | case_number | 2022-SC-000005 | |
     | x.is_represented | False | other_parties[0].is_represented |
     | x.address.address | 123 Fake St | other_parties[0].address.address |
     | x.address.city | Boston | other_parties[0].address.address |
@@ -120,11 +121,12 @@ Scenario: appearance.yml with e-filing, search by party name
   Given I start the interview at "appearance.yml"
   And the maximum seconds for each Step in this Scenario is 60
   And I check all pages for accessibility issues
+  # trial_court_index 97 is Tazewell
   And I get to the question id "eFile Login" with this data:
     | var | value | trigger |
     | accept["I accept the terms of use."] | True | |
     | case_is_invalid_type | False | |
-    | trial_court_index | 0 | |
+    | trial_court_index | 97 | |
     | user_wants_efile | True | |
   And I set the variable "my_username" to secret "TYLER_EMAIL"
   And I set the variable "my_password" to secret "TYLER_PASSWORD"
@@ -155,7 +157,7 @@ Scenario: appearance.yml with e-filing, search by party name
     | users[0].email | example@example.com | |
     | user_benefits['TA'] | True | |
     | users[0].birth_year | 2000 | |
-    | x.document_type | 273947 | illinois_appearance_bundle.document_type |
+    | x.document_type | 5766 | illinois_appearance_bundle.document_type |
   And I tap the "#efile" element
   #And I tap to continue
   #Then I should see the phrase "form was submitted"

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='docassemble.AppearanceEfile',
       url='https://www.illinoislegalaid.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.AssemblyLine>=3.1.0', 'docassemble.EFSPIntegration>=1.5.0', 'docassemble.ILAOEfile>=1.0.4'],
+      install_requires=['docassemble.AssemblyLine>=3.1.0', 'docassemble.EFSPIntegration>=1.5.0', 'docassemble.ILAOEfile>=1.0.4', 'docassemble.ILFeeWaiver @ git+https://github.com/IllinoisLegalAidOnline/docassemble-IlFeeWaiver.git@main'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/AppearanceEfile/', package='docassemble.AppearanceEfile'),
      )


### PR DESCRIPTION
Previously, the only allowed `document_type`s for a case were `5766` ("Non-confidential"), and `5767` ("Confidential"). Tyler has changed this language (which I'm now realizing always changes the code values they represent) to be "Public" and "Non-public". I have changed the search language to use the new terms, and changed the codes to the new values. I kept some of the old codes when checking for things, because I believe that the old codes are sometimes kept in older cases.

Got the new code numbers / names from the logs, and from https://efile.suffolklitlab.org/jurisdictions/illinois/codes/courts/KankakeeCV/filing_types/5957/document_types (unfortunately, the codes values themselves seem to be [different in `efile-test.suffolklitlab.org`](https://efile-test.suffolklitlab.org/jurisdictions/illinois/codes/courts/KankakeeCV/filing_types/5957/document_types), and I'm not sure of the reason yet. Names are the same though, and should still work). 

Fixes #15.